### PR TITLE
Fix ui freeze when unpacking lots of AB files

### DIFF
--- a/src/ResolveAB.py
+++ b/src/ResolveAB.py
@@ -472,7 +472,7 @@ def main(
         worker_count = min(len(flist), PerformanceLevel.get_process_limit(Config.get("performance_level")))
         Logger.info(f"ResolveAB: Using {worker_count} worker processes for {len(flist)} files")
 
-        task_queue: mp.Queue = ctx.Queue(maxsize=max(1, worker_count))
+        task_queue: mp.Queue = ctx.Queue(maxsize=max(64, worker_count * 8))
         result_bus = ProcessResultBus(ctx)
         result_sender = result_bus.create_sender()
 
@@ -502,6 +502,24 @@ def main(
         ProcessUtils.start_all(fs_guard, *workers)
         current_stage.set_value("正在分发任务")
 
+        worker_done = set()
+        fs_guard_done = False
+        fs_guard_stop_sent = False
+        fatal_error = None
+
+        def _set_fs_guard_done(_pid: int):
+            nonlocal fs_guard_done
+            fs_guard_done = True
+
+        result_bus = (
+            result_bus.set_on_file_queued(tr_file_saving.update_demand)
+            .set_on_file_saved(tr_file_saving.report)
+            .set_on_processed(tr_processed.report)
+            .set_on_worker_done(worker_done.add)
+            .set_on_fs_guard_done(_set_fs_guard_done)
+            .set_on_log(Logger.log)
+        )
+
         for i in flist:
             current_dir.set_value(osp.basename(osp.dirname(i)))
             panel.update()
@@ -529,28 +547,21 @@ def main(
                     do_tree=do_tree,
                 )
             )
+            result_bus.drain(timeout=0.0)
+            for worker in workers:
+                if worker.exitcode is not None and worker.pid not in worker_done:
+                    if worker.exitcode != 0:
+                        fatal_error = f'Worker process "{worker.name}" exited unexpectedly with code {worker.exitcode}'
+                        Logger.error(f"ResolveAB: {fatal_error}")
+                    worker_done.add(worker.pid)
+            if fatal_error:
+                break
+
         for _ in workers:
             task_queue.put(StopMessage())
 
         current_stage.set_value("正在处理任务")
         current_dir.set_value(None)
-        worker_done = set()
-        fs_guard_done = False
-        fs_guard_stop_sent = False
-        fatal_error = None
-
-        def _set_fs_guard_done(_pid: int):
-            nonlocal fs_guard_done
-            fs_guard_done = True
-
-        result_bus = (
-            result_bus.set_on_file_queued(tr_file_saving.update_demand)
-            .set_on_file_saved(tr_file_saving.report)
-            .set_on_processed(tr_processed.report)
-            .set_on_worker_done(worker_done.add)
-            .set_on_fs_guard_done(_set_fs_guard_done)
-            .set_on_log(Logger.log)
-        )
 
         while len(worker_done) < len(workers) or not fs_guard_done:
             result_bus.drain(timeout=0.1)


### PR DESCRIPTION
## 问题

解包大量 AB 文件（如 13000+）时，程序在"正在分发任务"阶段看似卡死：
- 进度条一直停在 `0 / N`，几分钟不动
- 用户无法判断程序是正常工作还是已冻结
- Worker 进程在此阶段崩溃无法被检测到，导致主进程永久死锁

根因：
1. **任务队列太小**（`maxsize=worker_count`）：使用 `spawn` 方式启动进程，
   每个 worker 需要 10-20 秒加载 UnityPy 的 C 扩展。队列填满后主进程的
   `task_queue.put()` 永久阻塞，而此时还没有 worker 准备好消费任务。
2. **回调注册太晚**：`result_bus` 的进度回调和 worker 完成跟踪是在分发
   *完成之后*才设置的。即使 worker 已经在处理文件，界面也不会更新。
3. **分发阶段无崩溃检测**：worker 退出状态只在分发后的监控循环中检查。
   如果 worker 在分发阶段崩溃（如 OOM 或 C 扩展段错误），主进程毫无感知
   并永远阻塞。

## 改动

仅修改 `src/ResolveAB.py`，+29 / -18 行：

1. **增大队列容量** `maxsize=max(64, worker_count * 8)` — 避免 worker
   启动期间主进程阻塞。
2. **将回调注册提前到分发循环之前** — 让 `result_bus.drain()` 能在分发
   阶段实时更新进度。
3. **分发循环内 drain + 检 worker 崩溃** — 每入队一个文件就 drain 一次
   进度，并检查是否有 worker 异常退出，一旦检测到立即报错终止。